### PR TITLE
Fix actors finalization

### DIFF
--- a/v6/003/celluloid/dining_philosophers.rb
+++ b/v6/003/celluloid/dining_philosophers.rb
@@ -31,6 +31,10 @@ class ActorPhilosopher < Philosopher
     @waiter.async.done_eating(Actor.current)
     think
   end
+
+  def finalize
+    drop_chopsitcks
+  end
 end
 
 class Waiter


### PR DESCRIPTION
When Celluloid receives an INT signals it terminates all running
actors. In this process an actor can be retaining a lock while
another one is waiting to obtain it. If the first actor never release
the lock, a deadlock might happen.
